### PR TITLE
docs(README.md): 新增安装 electron 失败时的解决办法

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ git clone https://github.com/liou666/polyglot.git
 
 # 2.安装依赖；
 cd polyglot
-pnpm install
+pnpm install 
+# 安装 electron 时, 执行 node install.js 失败时使用：
+# export ELECTRON_MIRROR=http://npm.taobao.org/mirrors/electron/ && pnpm i
 
 # 3.配置环境变量
 mv .env.example .env


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

执行 `pnpm i` 安装依赖时，有概率会在安装 electron 出错，错误内容: 

```bash
node_modules/electron postinstall$ node install.js
│ RequestError: unable to verify the first certificate
│     at ClientRequest.<anonymous> (C:\Users\atomw\Code\polyglot\node_modules\got\dist\source\core\index.js:970:111)
│     at Object.onceWrapper (node:events:628:26)
│     at ClientRequest.emit (node:events:525:35)
│     at origin.emit (C:\Users\atomw\Code\polyglot\node_modules\@szmarczak\http-timer\dist\source\index.js:43:20)
│     at TLSSocket.socketErrorListener (node:_http_client:502:9)
│     at TLSSocket.emit (node:events:513:28)
│     at emitErrorNT (node:internal/streams/destroy:151:8)
│     at emitErrorCloseNT (node:internal/streams/destroy:116:3)
│     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
│     at TLSSocket.onConnectSecure (node:_tls_wrap:1540:34)
│     at TLSSocket.emit (node:events:513:28)
│     at TLSSocket._finishInit (node:_tls_wrap:959:8)
│     at ssl.onhandshakedone (node:_tls_wrap:743:12)
└─ Failed in 224ms at C:\Users\atomw\Code\polyglot\node_modules\electron
 ELIFECYCLE  Command failed with exit code 1.
```

此时，将 `pnpm i` 命令替换为如下命令即可：

```bash
export ELECTRON_MIRROR=http://npm.taobao.org/mirrors/electron/ && pnpm i
```

已将此解决办法加入 README.md 文件中

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other
